### PR TITLE
↔️ Date range filtering

### DIFF
--- a/NEWBLACK X/Scenes/Launches/LaunchesView.swift
+++ b/NEWBLACK X/Scenes/Launches/LaunchesView.swift
@@ -18,10 +18,13 @@ struct LaunchesView: View {
     var page: Int? = 0
 
     @State
-    var dateRanges: [DateRangeToolbar.Filter] = []
+    var dateRanges: [DateRangeFilter.Filter] = []
 
     @State
     var filterDateRanges: Bool = false
+
+    @State
+    var showDateRangeFilter: Bool = false
 
     var body: some View {
         List {
@@ -72,7 +75,11 @@ struct LaunchesView: View {
             }
         }
         .toolbar {
-            DateRangeToolbar(isActive: $filterDateRanges, filters: $dateRanges) {
+            DateRangeToolbar(
+                isFilterActive: filterDateRanges,
+                showDateRangeFilter: $showDateRangeFilter
+            ) {
+                filterDateRanges = false
                 Task {
                     await refresh()
                 }
@@ -81,6 +88,19 @@ struct LaunchesView: View {
         .refreshable {
             await refresh()
         }
+        .popover(isPresented: $showDateRangeFilter) {
+            DateRangeFilter(
+                isActive: $filterDateRanges,
+                filters: $dateRanges
+            )
+            .presentationDetents([.medium, .large])
+            .onDisappear {
+                Task {
+                    await refresh()
+                }
+            }
+        }
+        .animation(.default, value: filterDateRanges)
     }
 
     private func refresh() async {

--- a/NEWBLACK X/Scenes/Launches/LaunchesView.swift
+++ b/NEWBLACK X/Scenes/Launches/LaunchesView.swift
@@ -26,6 +26,9 @@ struct LaunchesView: View {
     @State
     var showDateRangeFilter: Bool = false
 
+    @State
+    var showSkeleton: Bool = false
+
     var body: some View {
         List {
             ForEach(launches) { launch in
@@ -61,7 +64,6 @@ struct LaunchesView: View {
                     } actions: {
                         Button("Clear Filters") {
                             withAnimation {
-                                dateRanges.removeAll()
                                 filterDateRanges = false
                             }
 
@@ -74,6 +76,7 @@ struct LaunchesView: View {
                 }
             }
         }
+        .redacted(reason: showSkeleton ? [.placeholder] : [])
         .toolbar {
             DateRangeToolbar(
                 isFilterActive: filterDateRanges,
@@ -104,6 +107,8 @@ struct LaunchesView: View {
     }
 
     private func refresh() async {
+        showSkeleton = true
+        defer { showSkeleton = false }
         self.launches = await fetchPage(0)
     }
 

--- a/NEWBLACK X/Views/DateRangeFilter.swift
+++ b/NEWBLACK X/Views/DateRangeFilter.swift
@@ -1,0 +1,112 @@
+//
+//  DateRangeFilter.swift
+//  NEWBLACK X
+//
+//  Created by Dorian on 15/05/2025.
+//
+
+import SwiftUI
+
+struct DateRangeFilter: View {
+
+    @Binding
+    var isActive: Bool
+
+    @Binding
+    var filters: [Filter]
+
+    @State
+    private var startDate: Date = .now
+
+    @State
+    private var endDate: Date = .now
+
+    @State
+    private var showMissingFilterAlert = false
+
+    var body: some View {
+        List {
+            Toggle(isOn: .init(get: {
+                isActive
+            }, set: { newValue in
+                guard isActive || !filters.isEmpty else {
+                    withAnimation {
+                        showMissingFilterAlert.toggle()
+                    }
+                    UINotificationFeedbackGenerator().notificationOccurred(.error)
+                    return
+                }
+                isActive = newValue
+            })) {
+                Text("Enable Filter")
+            }
+            Section("Select Date Range") {
+                DatePicker("Start", selection: $startDate, displayedComponents: [.date])
+
+                DatePicker("End", selection: $endDate, displayedComponents: [.date])
+
+                Button("Add Date Range") {
+                    withAnimation {
+                        let range = startDate..<endDate
+                        filters.append(.init(range: range))
+                        isActive = true
+                        startDate = .now
+                        endDate = .now
+                    }
+                }
+                .shakeEffect(activate: showMissingFilterAlert, amount: 5, shakesPerUnit: 4)
+            }
+
+            Section {
+                if filters.isEmpty {
+                    Text("No date ranges - Create one to filter launches.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(filters) { filter in
+                        HStack {
+                            Text(filter.range.lowerBound.formatted(date: .numeric, time: .omitted))
+                            Text(" - ")
+                                .foregroundStyle(.secondary)
+                            Text(filter.range.upperBound.formatted(date: .numeric, time: .omitted))
+                        }
+                    }
+                    .onDelete { index in
+                        filters.remove(atOffsets: index)
+                    }
+                }
+            } header: {
+                HStack {
+                    Text("Date Ranges")
+                    Spacer()
+                    Button("Clear all") {
+                        withAnimation {
+                            filters.removeAll()
+                            isActive = false
+                        }
+                    }
+                    .textCase(nil)
+                    .font(.callout)
+                }
+            }
+        }
+    }
+
+    struct Filter: Hashable, Equatable, Identifiable {
+        let id = UUID()
+
+        let range: Range<Date>
+    }
+}
+
+#Preview {
+
+    @Previewable
+    @State
+    var isActive: Bool = false
+
+    @Previewable
+    @State
+    var filters: [DateRangeFilter.Filter] = []
+
+    DateRangeFilter(isActive: $isActive, filters: $filters)
+}

--- a/NEWBLACK X/Views/DateRangeToolbar.swift
+++ b/NEWBLACK X/Views/DateRangeToolbar.swift
@@ -9,106 +9,44 @@ import SwiftUI
 
 struct DateRangeToolbar: ToolbarContent {
 
-    @State
-    private var showDatePicker = false
+    let isFilterActive: Bool
 
     @Binding
-    var isActive: Bool
+    var showDateRangeFilter: Bool
 
-    @Binding
-    var filters: [Filter]
-
-    @State
-    var startDate: Date = .now
-
-    @State
-    var endDate: Date = .now
-
-    let onCommit: () -> Void
+    let disableFilter: () -> Void
 
     var body: some ToolbarContent {
+        if isFilterActive {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(action: {
+                    disableFilter()
+                }) {
+                    Text("Clear")
+                }
+            }
+        }
         ToolbarItem(placement: .navigationBarTrailing) {
             Button(action: {
-                showDatePicker.toggle()
+                showDateRangeFilter.toggle()
             }) {
-                Image(systemName: "line.3.horizontal.decrease.circle.fill")
+                Image(systemName:
+                        isFilterActive
+                      ? "line.3.horizontal.decrease.circle.fill"
+                      : "line.3.horizontal.decrease.circle"
+                )
             }
-            .popover(isPresented: $showDatePicker) {
-                datePicker
-                    .presentationDetents([.medium, .large])
-                    .onDisappear {
-                        onCommit()
-                    }
-            }
+            .navigationTitle(
+                isFilterActive
+                ? "Filtered by date"
+                : ""
+            )
+            .navigationBarTitleDisplayMode(.inline)
         }
-    }
-
-    private var datePicker: some View {
-        List {
-            Toggle(isOn: $isActive) {
-                Text("Enable Filter")
-            }
-            Section("Select Date Range") {
-                DatePicker("Start", selection: $startDate, displayedComponents: [.date])
-
-                DatePicker("End", selection: $endDate, displayedComponents: [.date])
-
-                Button("Add Date Range") {
-                    withAnimation {
-                        let range = startDate..<endDate
-                        filters.append(.init(range: range))
-                        isActive = true
-                        startDate = .now
-                        endDate = .now
-                    }
-                }
-            }
-
-            Section {
-                if filters.isEmpty {
-                    Text("No date ranges - Create one to filter launches.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(filters) { filter in
-                        HStack {
-                            Text(filter.range.lowerBound.formatted(date: .numeric, time: .omitted))
-                            Text(" - ")
-                                .foregroundStyle(.secondary)
-                            Text(filter.range.upperBound.formatted(date: .numeric, time: .omitted))
-                        }
-                    }
-                    .onDelete { index in
-                        filters.remove(atOffsets: index)
-                    }
-                }
-            } header: {
-                HStack {
-                    Text("Date Ranges")
-                    Spacer()
-                    Button("Clear all") {
-                        withAnimation {
-                            filters.removeAll()
-                        }
-                    }
-                    .textCase(nil)
-                    .font(.callout)
-                }
-            }
-        }
-    }
-
-    struct Filter: Hashable, Equatable, Identifiable {
-        let id = UUID()
-
-        let range: Range<Date>
     }
 }
 
 #Preview {
-
-    @Previewable
-    @State
-    var filters: [DateRangeToolbar.Filter] = []
 
     @Previewable
     @State
@@ -117,7 +55,10 @@ struct DateRangeToolbar: ToolbarContent {
     NavigationStack {
         Text("Hello, World!")
             .toolbar {
-                DateRangeToolbar(isActive: $isActive, filters: $filters) {}
+                DateRangeToolbar(
+                    isFilterActive: isActive,
+                    showDateRangeFilter: .constant(false)
+                ) {}
             }
     }
 }

--- a/NEWBLACK X/Views/ShakeEffect.swift
+++ b/NEWBLACK X/Views/ShakeEffect.swift
@@ -1,0 +1,25 @@
+//
+//  ShakeEffect.swift
+//  NEWBLACK X
+//
+//  Created by Dorian on 15/05/2025.
+//
+
+import SwiftUI
+
+struct ShakeEffect: GeometryEffect {
+    var amount: CGFloat = 8
+    var shakesPerUnit: CGFloat = 3
+    var animatableData: CGFloat
+    
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(CGAffineTransform(translationX: amount * sin(animatableData * .pi * shakesPerUnit), y: 0))
+    }
+}
+
+extension View {
+    /// Applies a shake effect to the view.
+    func shakeEffect(activate: Bool, amount: CGFloat = 8, shakesPerUnit: CGFloat = 3) -> some View {
+        self.modifier(ShakeEffect(amount: amount, shakesPerUnit: shakesPerUnit, animatableData: activate ? 1 : 0))
+    }
+}

--- a/Packages/Core/Sources/API/API.swift
+++ b/Packages/Core/Sources/API/API.swift
@@ -17,8 +17,21 @@ public final class API: Sendable {
 
     package init() {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .secondsSince1970
-        self.requestPerformer = RequestPerformer(session: .init(configuration: .ephemeral), decoder: decoder)
+        // The following is needed because it's 2025 and Apple still doesn't know how to decode
+        // ISO8601 dates with fractional seconds 😤
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let isoFormatter = ISO8601DateFormatter()
+            isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+            guard let date = isoFormatter.date(from: dateString) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Cannot decode ISO8601 date: \(dateString)")
+            }
+            return date
+        }
+        let encoder: JSONEncoder = .init()
+        encoder.dateEncodingStrategy = .iso8601
+        self.requestPerformer = RequestPerformer(session: .init(configuration: .ephemeral), encoder: encoder, decoder: decoder)
     }
 
     package func send<R: Request>(_ request: R) async throws -> R.Response {

--- a/Packages/Core/Sources/API/Common/Query/Query+Filter.swift
+++ b/Packages/Core/Sources/API/Common/Query/Query+Filter.swift
@@ -32,7 +32,7 @@ public extension Query {
         case compound(field: Item.Field, filters: [Filter])
 
         /// Creates a filter that checks if a field is contained in the given range.
-        static func range<T: Comparable & QueryComparable>(field: Item.Field, range: Range<T>) -> Filter {
+        public static func range<T: Comparable & QueryComparable>(field: Item.Field, range: Range<T>) -> Filter {
             .compound(field: field, filters: [
                 .lessThan(field: field, value: range.upperBound, inclusive: false),
                 .greaterThan(field: field, value: range.lowerBound, inclusive: true)
@@ -40,7 +40,7 @@ public extension Query {
         }
 
         /// Creates a filter that checks if a field is contained in the given closed range.
-        static func range<T: Comparable & QueryComparable>(field: Item.Field, range: ClosedRange<T>) -> Filter {
+        public static func range<T: Comparable & QueryComparable>(field: Item.Field, range: ClosedRange<T>) -> Filter {
             .compound(field: field, filters: [
                 .lessThan(field: field, value: range.upperBound, inclusive: true),
                 .greaterThan(field: field, value: range.lowerBound, inclusive: true)

--- a/Packages/Core/Sources/API/Common/Query/Query+Option.swift
+++ b/Packages/Core/Sources/API/Common/Query/Query+Option.swift
@@ -23,6 +23,9 @@ public extension Query {
         func encode(to container: inout KeyedEncodingContainer<DynamicCodingKey>) throws {
             switch self {
             case .select(let fields):
+                guard !fields.isEmpty && fields != Item.Field.allCases else {
+                    return
+                }
                 var nested = container.nestedUnkeyedContainer(forKey: "select")
                 for field in fields {
                     try nested.encode(field.rawValue)

--- a/Packages/Core/Sources/API/Entities/DTOs/Launch.swift
+++ b/Packages/Core/Sources/API/Entities/DTOs/Launch.swift
@@ -56,7 +56,7 @@ public struct Launch: DTO {
 
     public enum Field: String, CodingKey, DTOField {
         case id
-        case date = "date_unix"
+        case date = "date_utc"
         case isUpcoming = "upcoming"
         case name
         case launchpad = "launchpad"


### PR DESCRIPTION
This PR updates the date range filtering functionality across the API and UI layers. Key changes include:
- Updating the Launch DTO to map the date field to "date_utc" rather than "date_unix".
- Adjusting Query options and filters to support date range queries with new public API access.
- Overhauling the date filtering UI with new toolbar and popover components, alongside improved API date encoding/decoding.